### PR TITLE
cargo: bump version-sync dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ path = "derive"
 version = "=0.0.0" # AUTOBUMP
 
 [dev-dependencies]
-version-sync = "0.7"
+version-sync = "0.8"
 
 [workspace]
 


### PR DESCRIPTION
The new version 0.8.0 requires Rust 2018, which this project is already using.